### PR TITLE
Fixed igraph lib linked too early

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,4 +3,4 @@ INCLUDE	= -I/usr/local/include/igraph -I/usr/local/include/eigen3
 LIB	= -L/usr/local/lib -ligraph
 
 main: graphKernels_test.cc graphKernels.h
-	g++ -O3 $(INCLUDE) $(LIB) graphKernels_test.cc -o gkernel
+	g++ -O3 $(INCLUDE) graphKernels_test.cc $(LIB) -o gkernel


### PR DESCRIPTION
This fix moves the link arguments for igraph to the right, to fix a build error with g++ 5.4.0. This fix was necessary for graph-kernels to build on my computer. It is possible that this was not necessary previously, as the default linker behaviour might have changed.

### Cause
Some C/C++ compilers (actually linkers) resolve dependencies only from left-to-right. This means that dependencies (symbols) in files to the left can be resolved by files (libraries) that are further to the right. As such, the order of arguments matter.